### PR TITLE
Update serve to 9.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "cross-env": "^5.1.5",
     "css-loader": "^0.28.11",
     "mini-css-extract-plugin": "^0.4.0",
-    "serve": "^6.5.5",
+    "serve": "^9.6.0",
     "style-loader": "^0.21.0",
     "svelte": "^2.0.0",
     "svelte-loader": "2.9.0",


### PR DESCRIPTION
I've updated `serve` to version 9.6.0 since it's the latest version.

To test: `npm install` and make sure package to json is correct.

Do you know what `serve` does in the repo?