### PR TITLE
Eslint prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "plugins": ["prettier"],
+  "parserOptions": {
+    "sourceType": "module",
+    "allowImportExportEverywhere": false
+  },
+  "rules": {
+    "prettier/prettier": "error"
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "prettier/prettier": [
+    "error",
+    {
+      "singleQuote": false,
+      "semi": true,
+      "tabWidth": 2,
+      "parser": "babel"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack",
-    "dev": "webpack-serve --content public --hot"
+    "dev": "webpack-serve --content public --hot",
+    "lint": "eslint --fix --ext .js src"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "devDependencies": {
     "cross-env": "^5.1.5",
     "css-loader": "^0.28.11",
+    "eslint": "^4.19.1",
+    "eslint-plugin-prettier": "^2.6.2",
     "mini-css-extract-plugin": "^0.4.0",
     "serve": "^9.6.0",
     "style-loader": "^0.21.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,10 @@
-import App from './App.html';
+import App from "./App.html";
 
 const app = new App({
-	target: document.body,
-	data: {
-		name: 'world'
-	}
+  target: document.body,
+  data: {
+    name: "world"
+  }
 });
 
 window.app = app;


### PR DESCRIPTION
Among several popular eslint/prettier integration options, [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier) requires the fewest dependencies and is the simplest for our needs.

It would be enough to only use prettier. We agreed on just a few simple rules (semicolons, double-quotes, and 2-space indents), all of which come out-of-the-box with prettier defaults.

I declared prettier rules in `.prettierrc` for the rules we agreed upon to override local editor settings (for instance, I have `prettier.singleQuote` set to true in my user settings).

The eslint plugin allows us to use eslint's robust configuration as well as any eslint plugins we may choose down the road along and prettier without conflicts. Eslint will handle all rules in the standard way. It will provide feedback (error – and red, squiggly line) if a prettier rule is broken, but will yield to prettier for handling in those cases.

Compared with [prettier-eslint](https://github.com/prettier/prettier-eslint) and [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier).

TODO: While this solution meets the requirements we discussed, it does not account for linting within svelte components (*.html). That's better saved for another issue, but I'll just leave these links here: 

+ [eslint-plugin-svelte](https://github.com/tivac/eslint-plugin-svelte)
+ [svelte-prettier-eslint](https://github.com/Askoth/svelte-prettier-eslint)
+ [svelte's svelte-extras](https://github.com/sveltejs/svelte-extras/blob/master/package.json) (as an example)
+ [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html)

